### PR TITLE
asl: include string.h for memcpy

### DIFF
--- a/src/aligncan.c
+++ b/src/aligncan.c
@@ -1,4 +1,5 @@
 #include "aligncan.h"
+#include <string.h>
 
 #if defined(ALIGN_CAN_USE_BUFFER)
 Align_CAN_BufferTypeDef Align_CAN_Buffer[ALIGN_CAN_BUFFER_SIZE] = {0};


### PR DESCRIPTION
GCC 14 no longer allows implicit function declarations, and aligncan.c calls memcpy without a prototype.

This adds the missing <string.h> include so the AR25 build succeeds with stricter toolchains.
No functional behavior change intended.